### PR TITLE
Remove dependency from X11::Protocol and use names instead of numbers for variable $type 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,10 +2,9 @@
 i3tree is a program I wrote to help myself adjust to version 4 of the i3 tiling window manager. It displays the containers your windows are children of and what layout those containers are using.
 
 ## INSTALLATION
-i3tree requires an installation of the i3 window manager, perl, and the following two perl modules.
+i3tree requires an installation of the i3 window manager, perl, and the following perl module.
 
   * AnyEvent::I3
-  * X11::Protocol
 
 ## USAGE
 Just run it.

--- a/i3tree
+++ b/i3tree
@@ -3,9 +3,8 @@
 # use {{{
 use strict;
 use warnings;
-use v5.20;
+use v5.14;
 use AnyEvent::I3;
-use Data::Dumper;
 # }}}
 
 # Variables {{{

--- a/i3tree
+++ b/i3tree
@@ -1,31 +1,24 @@
 #!/usr/bin/env perl
 
-# use {{{
 use strict;
 use warnings;
 use v5.14;
 use AnyEvent::I3;
-# }}}
 
-# Variables {{{
 
 # receive description of the tree
 my $tree = i3->get_tree->recv;
 
-# }}}
 
 walk_tree( $tree, 0 );
 
-# sub display_node {{{
 sub display_node {
     my ( $description, $depth ) = @_;
     my $margin = "\t" x $depth;
     print $margin . $description . "\n";
     return $depth + 1;
 }
-# }}}
 
-# sub walk_tree {{{
 
 sub walk_tree {
     my ( $node, $depth ) = @_;
@@ -63,4 +56,3 @@ sub walk_tree {
     }
 }
 
-# }}}

--- a/i3tree
+++ b/i3tree
@@ -1,29 +1,32 @@
 #!/usr/bin/env perl
 
+# use {{{
 use strict;
 use warnings;
-
+use v5.20;
 use AnyEvent::I3;
-use X11::Protocol;
+use Data::Dumper;
+# }}}
 
-# get path to i3 socket by reading property of X11 root window
-my $x = X11::Protocol->new();
-my ( $value, $mtype, $format, $bytes_after ) =
-  $x->GetProperty( $x->root, $x->atom('I3_SOCKET_PATH'),
-    'AnyPropertyType', 0, -1, 0 );
+# Variables {{{
 
-my $i3 = i3($value);
-$i3->connect->recv or die "Error connecting";
+# receive description of the tree
+my $tree = i3->get_tree->recv;
 
-# 4 is message type to receive description of the tree
-my $tree = $i3->message(4)->recv;
+# }}}
 
+walk_tree( $tree, 0 );
+
+# sub display_node {{{
 sub display_node {
     my ( $description, $depth ) = @_;
     my $margin = "\t" x $depth;
     print $margin . $description . "\n";
     return $depth + 1;
 }
+# }}}
+
+# sub walk_tree {{{
 
 sub walk_tree {
     my ( $node, $depth ) = @_;
@@ -33,13 +36,16 @@ sub walk_tree {
     my $layout      = $node->{'layout'};
     my $name        = $node->{'name'};
 
-    # 4 is type for workspace
-    if ( $type == 4 ) {
+	# get type and name, for debugging
+	# say "$type, $name";
+
+    # if "type" is workspace
+    if ( $type eq "workspace" ) {
         $depth = display_node( "Workspace $name ($layout - $orientation)", $depth );
     }
 
-    # 2 is type for several kinds of containers
-    if ( $type == 2 ) {
+    # if "type" is "con" (type for several kinds of containers)
+    if ( $type eq "con" ) {
         # no orientation, so probably a window
         if ( $orientation eq "none" ) {
             # filter out two possible non-windows
@@ -58,5 +64,4 @@ sub walk_tree {
     }
 }
 
-walk_tree( $tree, 0 );
-
+# }}}


### PR DESCRIPTION
The script was not working as the variable "$type" was using strings instead of "numbers". Also, the dependency from X11::Protocol is no longer needed. 
