### PR TITLE
Some suggestions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,37 +1,48 @@
-## OVERVIEW
-i3tree is a program I wrote to help myself adjust to version 4 of the i3 tiling window manager. It displays the containers your windows are children of and what layout those containers are using.
+# i3tree
 
-## INSTALLATION
+i3tree is a program I wrote to help myself adjust to version 4 of the i3 tiling window manager.
+It displays the containers your windows are children of and what layout those containers are using.
+
+## Installation
+
 i3tree requires an installation of the i3 window manager, perl, and the following perl module.
 
   * AnyEvent::I3
 
-## USAGE
+## Usage
+
 Just run it.
 
-## EXAMPLES
+## Examples
 
-    $  i3tree
-    Workspace 1 (horizontal)
-            Window foo@bar: ~
-            Split (vertical)
-                    Window foo@bar: ~
-                    Window foo@bar: ~
-    Workspace 2 (vertical)
-            Window foo@bar: ~
-            Window foo@bar: ~
+```shell
+$ i3tree
+  Workspace 1 (horizontal)
+      Window foo@bar: ~
+      Split (vertical)
+          Window foo@bar: ~
+*         Window foo@bar: ~
+  Workspace 2 (vertical)
+      Window foo@bar: ~
+      Window foo@bar: ~
+```
 
-## CONVENIENCE
-You could either start i3tree from a running terminal, or launch it
-inside a floating window.  Here's the configuration needed:
+`*` indicates the currently focused container.
+
+## Convenience
+
+You could either start i3tree from a running terminal, or launch it inside a floating window.
+Here's the configuration needed:
 
 ```
 for_window [title="^i3tree$"] floating enable
 bindsym $mod+t exec xterm -hold -title i3tree -e ~/path/to/i3tree
 ```
 
-## LIMITATIONS
+## Limitations
+
 i3tree shows containers from all workspaces. It could be useful to optionally limit this to only the current workspace.
 
-## THANKS
+## Thanks
+
 Thanks to everyone who has contributed to i3.

--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,7 @@ Just run it.
 ## Examples
 
 ```shell
+$ tabs 4
 $ i3tree
   Workspace 1 (horizontal)
       Window foo@bar: ~
@@ -28,6 +29,8 @@ $ i3tree
 ```
 
 `*` indicates the currently focused container.
+
+In POSIX-compliant terminals, use [`tabs`](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tabs.html) to adjust indentation width.
 
 ## Convenience
 

--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ Just run it.
 
 ## Examples
 
-```shell
+```console
 $ tabs 4
 $ i3tree
   Workspace 1 (horizontal)

--- a/i3tree
+++ b/i3tree
@@ -15,9 +15,10 @@ my $tree = i3->get_tree->recv;
 walk_tree( $tree, 0 );
 
 sub display_node {
-    my ( $description, $depth ) = @_;
+    my ( $description, $depth, $is_focused ) = @_;
     my $margin = "\t" x $depth;
-    print $margin . $description . "\n";
+    my $marker = $is_focused ? "* " : "  ";
+    print $marker . $margin . $description . "\n";
     return $depth + 1;
 }
 
@@ -29,13 +30,14 @@ sub walk_tree {
     my $orientation = $node->{'orientation'};
     my $layout      = $node->{'layout'};
     my $name        = $node->{'name'};
+    my $is_focused  = $node->{'focused'};
 
 	# get type and name, for debugging
 	# say "$type, $name";
 
     # if "type" is workspace
     if ( $type eq "workspace" ) {
-        $depth = display_node( "Workspace $name ($layout - $orientation)", $depth );
+        $depth = display_node( "Workspace $name ($layout - $orientation)", $depth, $is_focused );
     }
 
     # if "type" is "con" (type for several kinds of containers)
@@ -44,12 +46,12 @@ sub walk_tree {
         if ( $orientation eq "none" ) {
             # filter out two possible non-windows
             unless ( $name eq "content" or $name =~ "^i3bar" ) {
-                $depth = display_node( "Window $name", $depth );
+                $depth = display_node( "Window $name", $depth, $is_focused );
             }
         }
         # orientation, so definitely a split container
         else {
-            $depth = display_node( "Split ($layout - $orientation)", $depth );
+            $depth = display_node( "Split ($layout - $orientation)", $depth, $is_focused );
         }
     }
 

--- a/i3tree
+++ b/i3tree
@@ -1,5 +1,7 @@
 #!/usr/bin/env perl
 
+use open qw(:std :utf8);
+
 use strict;
 use warnings;
 use v5.14;


### PR DESCRIPTION
- Enable support for UTF-8 (otherwise, the output is mixed with "Wide character in print at /usr/bin/i3tree line 18." errors).
- Add a marker of the currently focused container (`*`).
- Opinionated adjustments to the readme.